### PR TITLE
fix jest warnings

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "types": ["node", "jest"]
   },
   "include": [
     "src"


### PR DESCRIPTION
Two separate tsconfig files is problematic.  Warnings that describe and it couldn't be found were occuring in the server folder.  Adding jest to types in the client folder's config file resolved the issue.